### PR TITLE
Add a error check in the loop.Break on error

### DIFF
--- a/tglib/cert.go
+++ b/tglib/cert.go
@@ -136,11 +136,19 @@ func Verify(signingCertPEMData []byte, certPEMData []byte, keyUsages []x509.ExtK
 func ReadCertificate(certPemBytes []byte, keyPemBytes []byte, password string) (*x509.Certificate, crypto.PrivateKey, error) {
 
 	certBlock, rest := pem.Decode(certPemBytes)
+
+	if certBlock == nil {
+		return nil, nil, fmt.Errorf("Unable to decode block")
+	}
 	for {
 		if len(rest) == 0 {
 			break
 		}
 		certBlock, rest = pem.Decode(rest)
+
+		if certBlock == nil {
+			break
+		}
 	}
 
 	if certBlock == nil {


### PR DESCRIPTION
If we send a malformed PEM.( for eg with a traling \n) The code loops forever. 
This adds an error check in the loop so we can break 
Also the same error check to not run the loop at all if pem cannot be decoded 