### PR TITLE
new: use fonctional args for Issue and Sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,11 @@ lint:
 		./...
 
 test:
-	go test ./... -race -cover -covermode=atomic -coverprofile=unit_coverage.cov
+	@ echo 'mode: atomic' > unit_coverage.cov
+	@ for d in $(shell go list ./... | grep -v vendor); do \
+		go test -race -coverprofile=profile.out -covermode=atomic "$$d" && \
+		if [ -f profile.out ]; then tail -q -n +2 profile.out >> unit_coverage.cov; rm -f profile.out; fi; \
+	done;
 
 coverage_aggregate:
 	@ mkdir -p artifacts

--- a/Makefile
+++ b/Makefile
@@ -15,15 +15,15 @@ ci: init lint test codecov build_linux build_darwin build_windows package
 	if [[ -f Gopkg.toml ]] ; then cp Gopkg.toml artifacts/ ; fi
 	if [[ -f Gopkg.lock ]] ; then cp Gopkg.lock artifacts/ ; fi
 	if [[ -d build/ ]] ; then cp -r build/ artifacts/build/ ; fi
-	# go get ./...
-	dep ensure
-	dep status
 
 init:
+	echo running dep ensure...
+	dep ensure
+	dep status || true
 	go generate ./...
 
 lint:
-	@ go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
+	go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 	golangci-lint run \
 		--deadline=3m \
 		--disable-all \

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ init:
 	go generate ./...
 
 lint:
+	@ go get -u github.com/golangci/golangci-lint/cmd/golangci-lint
 	golangci-lint run \
 		--deadline=3m \
 		--disable-all \

--- a/Makefile
+++ b/Makefile
@@ -30,20 +30,18 @@ lint:
 		--enable=errcheck \
 		--enable=goimports \
 		--enable=ineffassign \
-		--enable=govet \
 		--enable=golint \
 		--enable=unused \
 		--enable=structcheck \
 		--enable=varcheck \
 		--enable=deadcode \
 		--enable=unconvert \
-		--enable=goconst \
-		--enable=gosimple \
 		--enable=misspell \
-		--enable=staticcheck \
-		--enable=unparam \
 		--enable=prealloc \
 		--enable=nakedret \
+		--enable=gosimple \
+		--enable=govet \
+		--enable=staticcheck \
 		--enable=typecheck \
 		./...
 

--- a/tglib/cert_test.go
+++ b/tglib/cert_test.go
@@ -2,6 +2,7 @@ package tglib
 
 import (
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/pem"
 	"testing"
 	"time"
@@ -13,28 +14,9 @@ func TestIssue(t *testing.T) {
 
 	Convey("Given I issue root ECDSA CA", t, func() {
 
-		cacert, cakey, err := IssueCertiticate(
-			nil,
-			nil,
-			ECPrivateKeyGenerator,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			nil,
-			"my-ca",
-			nil,
-			nil,
-			time.Now(),
-			time.Now().Add(2*time.Hour),
-			x509.KeyUsageCRLSign|x509.KeyUsageCertSign,
-			nil,
-			x509.ECDSAWithSHA384,
-			x509.ECDSA,
-			true,
-			nil,
+		cacert, cakey, err := Issue(
+			pkix.Name{CommonName: "my-ca"},
+			OptIssueTypeCA(),
 		)
 
 		Convey("Then err should be nil", func() {
@@ -55,30 +37,10 @@ func TestIssue(t *testing.T) {
 
 		Convey("When I Issue a cert from that CA", func() {
 
-			x509cacert, x509cakey, _ := ReadCertificate(pem.EncodeToMemory(cacert), pem.EncodeToMemory(cakey), "")
-
-			cert, _, err := IssueCertiticate(
-				x509cacert,
-				x509cakey,
-				ECPrivateKeyGenerator,
-				nil,
-				nil,
-				nil,
-				nil,
-				nil,
-				nil,
-				nil,
-				"my-ca",
-				nil,
-				nil,
-				time.Now(),
-				time.Now().Add(2*time.Hour),
-				x509.KeyUsageCRLSign|x509.KeyUsageCertSign,
-				[]x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
-				x509.ECDSAWithSHA384,
-				x509.ECDSA,
-				false,
-				nil,
+			cert, _, err := Issue(
+				pkix.Name{CommonName: "my-cert"},
+				OptIssueSignerPEMBlock(cacert, cakey, ""),
+				OptIssueTypeServerAuth(),
 			)
 
 			Convey("Then err should be nil", func() {
@@ -159,6 +121,7 @@ func TestIssue(t *testing.T) {
 		})
 	})
 }
+
 func TestParseCertificates(t *testing.T) {
 
 	Convey("Given I have a valid single certificate pem bytes", t, func() {

--- a/tglib/deprecated.go
+++ b/tglib/deprecated.go
@@ -1,0 +1,114 @@
+package tglib
+
+import (
+	"crypto"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"time"
+)
+
+// IssueCertiticate issues a new Certificate eventual signed using the signingCertificate
+// and the given keyGen.
+func IssueCertiticate(
+	signingCertificate *x509.Certificate,
+	signingPrivateKey crypto.PrivateKey,
+	keyGen PrivateKeyGenerator,
+
+	countries []string,
+	provinces []string,
+	localities []string,
+	streetAddresses []string,
+	postalCodes []string,
+	organizations []string,
+	organizationalUnits []string,
+	commonName string,
+
+	dnsNames []string,
+	ipAddresses []net.IP,
+
+	beginning time.Time,
+	expiration time.Time,
+	keyUsage x509.KeyUsage,
+	extKeyUsage []x509.ExtKeyUsage,
+	signatureAlgorithm x509.SignatureAlgorithm,
+	publicKeyAlgorithm x509.PublicKeyAlgorithm,
+	isCA bool,
+
+	policies []asn1.ObjectIdentifier,
+
+) (*pem.Block, *pem.Block, error) {
+
+	fmt.Println("DEPRECATED: tglib.IssueCertiticate is deprecated in favor or tglib.Issue")
+
+	options := []IssueOption{
+		OptIssueKeyGenerator(keyGen),
+		OptIssueDNSSANs(dnsNames...),
+		OptIssueIPSANs(ipAddresses...),
+		OptIssueValidity(beginning, expiration),
+		OptIssueKeyUsage(keyUsage),
+		OptIssueExtendedKeyUsages(extKeyUsage...),
+		OptIssueSignatureAlgorithm(signatureAlgorithm),
+		OptIssuePublicKeyAlgorithm(publicKeyAlgorithm),
+	}
+
+	if signingCertificate != nil {
+		options = append(options, OptIssueSigner(signingCertificate, signingPrivateKey))
+	}
+
+	if isCA {
+		options = append(options, OptIssueTypeCA())
+	}
+
+	return Issue(
+		pkix.Name{
+			Country:            countries,
+			Locality:           localities,
+			Province:           provinces,
+			StreetAddress:      streetAddresses,
+			PostalCode:         postalCodes,
+			Organization:       organizations,
+			OrganizationalUnit: organizationalUnits,
+			CommonName:         commonName,
+		},
+		options...,
+	)
+}
+
+// SignCSR will sign the given CSR with the given signing cert
+func SignCSR(
+	csr *x509.CertificateRequest,
+	signingCertificate *x509.Certificate,
+	signingPrivateKey crypto.PrivateKey,
+
+	beginning time.Time,
+	expiration time.Time,
+	keyUsage x509.KeyUsage,
+	extKeyUsage []x509.ExtKeyUsage,
+	signatureAlgorithm x509.SignatureAlgorithm,
+	publicKeyAlgorithm x509.PublicKeyAlgorithm,
+
+	isCA bool,
+	policies []asn1.ObjectIdentifier,
+) (*pem.Block, string, error) {
+
+	fmt.Println("DEPRECATED: tglib.SignCSR is deprecated in favor or tglib.Sign")
+
+	options := []IssueOption{
+		OptIssueSigner(signingCertificate, signingPrivateKey),
+		OptIssueValidity(beginning, expiration),
+		OptIssueKeyUsage(keyUsage),
+		OptIssueExtendedKeyUsages(extKeyUsage...),
+		OptIssueSignatureAlgorithm(signatureAlgorithm),
+		OptIssuePublicKeyAlgorithm(publicKeyAlgorithm),
+	}
+
+	if isCA {
+		options = append(options, OptIssueTypeCA())
+	}
+
+	return Sign(csr, signingCertificate, signingPrivateKey, options...)
+}

--- a/tglib/options.go
+++ b/tglib/options.go
@@ -1,0 +1,214 @@
+package tglib
+
+import (
+	"crypto"
+	"crypto/x509"
+	"encoding/asn1"
+	"encoding/pem"
+	"net"
+	"time"
+)
+
+type issueCfg struct {
+	signingCertificate *x509.Certificate
+	signingPrivateKey  crypto.PrivateKey
+	keyGen             PrivateKeyGenerator
+	signatureAlgorithm x509.SignatureAlgorithm
+	publicKeyAlgorithm x509.PublicKeyAlgorithm
+	policies           []asn1.ObjectIdentifier
+	dnsNames           []string
+	ipAddresses        []net.IP
+	beginning          time.Time
+	expiration         time.Time
+	keyUsage           x509.KeyUsage
+	extKeyUsage        []x509.ExtKeyUsage
+	isCA               bool
+}
+
+func newIssueCfg() issueCfg {
+	return issueCfg{
+		keyGen:             ECPrivateKeyGenerator,
+		signatureAlgorithm: x509.ECDSAWithSHA384,
+		publicKeyAlgorithm: x509.ECDSA,
+		beginning:          time.Now().Add(-1 * time.Hour),
+		expiration:         time.Now().Add(12 * 31 * 24 * time.Hour),
+	}
+}
+
+// IssueOption represents an issueing option.
+type IssueOption func(*issueCfg)
+
+// OptIssueSigner sets the signer for the certificate to be issued.
+// By default, Issue will issue a self-signed certificate.
+func OptIssueSigner(cert *x509.Certificate, key crypto.PrivateKey) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.signingCertificate = cert
+		cfg.signingPrivateKey = key
+	}
+}
+
+// OptIssueSignerPEMBytes sets the signer for the certificate to be issued in the PEM format.
+// By default, Issue will issue a self-signed certificate.
+func OptIssueSignerPEMBytes(cert []byte, key []byte, password string) IssueOption {
+	return func(cfg *issueCfg) {
+		cert, key, err := ReadCertificate(cert, key, password)
+		if err != nil {
+			panic(err)
+		}
+		OptIssueSigner(cert, key)(cfg)
+	}
+}
+
+// OptIssueSignerPEMBlock sets the signer for the certificate to be issued in the PEM format.
+// By default, Issue will issue a self-signed certificate.
+func OptIssueSignerPEMBlock(cert *pem.Block, key *pem.Block, password string) IssueOption {
+	return func(cfg *issueCfg) {
+		OptIssueSignerPEMBytes(pem.EncodeToMemory(cert), pem.EncodeToMemory(key), password)(cfg)
+	}
+}
+
+// OptIssueValidity sets the validity of the certificate to be issued.
+// By default, the certificate is valid from the time it has been created
+// for 1 year.
+func OptIssueValidity(notBefore time.Time, notAfter time.Time) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.beginning = notBefore
+		cfg.expiration = notAfter
+	}
+}
+
+// OptIssueTypeCA sets the makes the certificate to be issued to be
+// a Certificate Authority.
+// It automatically applies the correct key usage, unless already
+// set by another option.
+func OptIssueTypeCA() IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.isCA = true
+		cfg.keyUsage |= x509.KeyUsageCRLSign | x509.KeyUsageCertSign
+	}
+}
+
+// OptIssueTypeServerAuth configures the certificate to be issued to be a server certificate.
+// This option can be combined with other OptIssueType*.
+func OptIssueTypeServerAuth() IssueOption {
+	return func(cfg *issueCfg) {
+		OptIssueExtendedKeyUsages(x509.ExtKeyUsageServerAuth)(cfg)
+		cfg.keyUsage |= x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	}
+}
+
+// OptIssueTypeClientAuth configures the certificate to be issued to be a client certificate.
+// This option can be combined with other OptIssueType*.
+func OptIssueTypeClientAuth() IssueOption {
+	return func(cfg *issueCfg) {
+		OptIssueExtendedKeyUsages(x509.ExtKeyUsageClientAuth)(cfg)
+		cfg.keyUsage |= x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	}
+}
+
+// OptIssueTypeEmailProtection configures the certificate to be issued to be a email protection certificate.
+// This option can be combined with other OptIssueType*.
+func OptIssueTypeEmailProtection() IssueOption {
+	return func(cfg *issueCfg) {
+		OptIssueExtendedKeyUsages(x509.ExtKeyUsageEmailProtection)(cfg)
+		cfg.keyUsage |= x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	}
+}
+
+// OptIssueTypeCodeSigning configures the certificate to be issued to be a code signing certificate.
+// This option can be combined with other OptIssueType*.
+func OptIssueTypeCodeSigning() IssueOption {
+	return func(cfg *issueCfg) {
+		OptIssueExtendedKeyUsages(x509.ExtKeyUsageCodeSigning)(cfg)
+		cfg.keyUsage |= x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
+	}
+}
+
+// OptIssueIPSANs sets the IP SANs for the certificate to be issued.
+func OptIssueIPSANs(ips ...net.IP) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.ipAddresses = ips
+	}
+}
+
+// OptIssueDNSSANs the IP SANs for the certificate to be issued.
+func OptIssueDNSSANs(dns ...string) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.dnsNames = dns
+	}
+}
+
+// OptIssueAlgorithmECDSA configures the certificate to use ECDSA with SHA384 P256 curve.
+func OptIssueAlgorithmECDSA() IssueOption {
+	return func(cfg *issueCfg) {
+		OptIssueKeyGenerator(ECPrivateKeyGenerator)(cfg)
+		OptIssueSignatureAlgorithm(x509.ECDSAWithSHA384)(cfg)
+		OptIssuePublicKeyAlgorithm(x509.ECDSA)(cfg)
+	}
+}
+
+// OptIssueAlgorithmRSA configures the certificate to use 2048-bits RSA with SHA384 signature
+func OptIssueAlgorithmRSA() IssueOption {
+	return func(cfg *issueCfg) {
+		OptIssueKeyGenerator(RSAPrivateKeyGenerator)(cfg)
+		OptIssueSignatureAlgorithm(x509.SHA384WithRSA)(cfg)
+		OptIssuePublicKeyAlgorithm(x509.RSA)(cfg)
+	}
+}
+
+// OptIssueExtendedKeyUsages manually sets the extended key usage for the certificate.
+// It will erase any previous extended usage set by options OptIssueType*.
+//
+// It is not recommended to use this option unless you know exactly what you are doing.
+func OptIssueExtendedKeyUsages(usages ...x509.ExtKeyUsage) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.extKeyUsage = usages
+	}
+}
+
+// OptIssueKeyUsage sets the key usage for the certificate.
+// It will erase any previous usage set by options OptIssueType*.
+//
+// It is not recommended to use this option unless you know exactly what you are doing.
+func OptIssueKeyUsage(usage x509.KeyUsage) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.keyUsage = usage
+	}
+}
+
+// OptIssueKeyGenerator sets the private key generator to use.
+// It will erase any previous extended usage set by options OptIssueAlgorithm*.
+//
+// It is not recommended to use this option unless you know exactly what you are doing.
+func OptIssueKeyGenerator(keyGen PrivateKeyGenerator) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.keyGen = keyGen
+	}
+}
+
+// OptIssuePublicKeyAlgorithm sets the signature algorithm for the public key.
+// It will erase any previous extended usage set by options OptIssueAlgorithm*.
+//
+// It is not recommended to use this option unless you know exactly what you are doing.
+func OptIssuePublicKeyAlgorithm(alg x509.PublicKeyAlgorithm) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.publicKeyAlgorithm = alg
+	}
+}
+
+// OptIssueSignatureAlgorithm sets the signature algorithm for the certificate.
+// By default, it uses x509.ECDSA.
+//
+// It is not recommended to use this option unless you know exactly what you are doing.
+func OptIssueSignatureAlgorithm(alg x509.SignatureAlgorithm) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.signatureAlgorithm = alg
+	}
+}
+
+// OptIssuePolicies sets additional policies OIDs.
+func OptIssuePolicies(policies ...asn1.ObjectIdentifier) IssueOption {
+	return func(cfg *issueCfg) {
+		cfg.policies = policies
+	}
+}

--- a/tglib/options.go
+++ b/tglib/options.go
@@ -35,7 +35,7 @@ func newIssueCfg() issueCfg {
 	}
 }
 
-// IssueOption represents an issueing option.
+// IssueOption represents an issuing option.
 type IssueOption func(*issueCfg)
 
 // OptIssueSigner sets the signer for the certificate to be issued.

--- a/tglib/options.go
+++ b/tglib/options.go
@@ -92,7 +92,7 @@ func OptIssueTypeCA() IssueOption {
 // This option can be combined with other OptIssueType*.
 func OptIssueTypeServerAuth() IssueOption {
 	return func(cfg *issueCfg) {
-		OptIssueExtendedKeyUsages(x509.ExtKeyUsageServerAuth)(cfg)
+		cfg.extKeyUsage = append(cfg.extKeyUsage, x509.ExtKeyUsageServerAuth)
 		cfg.keyUsage |= x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
 	}
 }
@@ -101,7 +101,7 @@ func OptIssueTypeServerAuth() IssueOption {
 // This option can be combined with other OptIssueType*.
 func OptIssueTypeClientAuth() IssueOption {
 	return func(cfg *issueCfg) {
-		OptIssueExtendedKeyUsages(x509.ExtKeyUsageClientAuth)(cfg)
+		cfg.extKeyUsage = append(cfg.extKeyUsage, x509.ExtKeyUsageClientAuth)
 		cfg.keyUsage |= x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
 	}
 }
@@ -110,7 +110,7 @@ func OptIssueTypeClientAuth() IssueOption {
 // This option can be combined with other OptIssueType*.
 func OptIssueTypeEmailProtection() IssueOption {
 	return func(cfg *issueCfg) {
-		OptIssueExtendedKeyUsages(x509.ExtKeyUsageEmailProtection)(cfg)
+		cfg.extKeyUsage = append(cfg.extKeyUsage, x509.ExtKeyUsageEmailProtection)
 		cfg.keyUsage |= x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
 	}
 }
@@ -119,7 +119,7 @@ func OptIssueTypeEmailProtection() IssueOption {
 // This option can be combined with other OptIssueType*.
 func OptIssueTypeCodeSigning() IssueOption {
 	return func(cfg *issueCfg) {
-		OptIssueExtendedKeyUsages(x509.ExtKeyUsageCodeSigning)(cfg)
+		cfg.extKeyUsage = append(cfg.extKeyUsage, x509.ExtKeyUsageCodeSigning)
 		cfg.keyUsage |= x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment
 	}
 }


### PR DESCRIPTION
This pr deprecated `IssueCertificates` and `SignCSR` in favor or `Issue` and `Sign`. The laters use functional arguments to make usage way easier. Options allows fine tuning as before, or provides high level versions that makes configuration easy.